### PR TITLE
Initialize composite bytebuffer for general List<Float> infercace usage.

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/PrimitiveFloatList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/PrimitiveFloatList.java
@@ -48,9 +48,6 @@ public class PrimitiveFloatList extends AbstractList<Float>
     if (capacity != 0) {
       elements = new float[capacity];
     }
-  }
-
-  public PrimitiveFloatList() {
     byteBuffer = new CompositeByteBuffer();
   }
 
@@ -129,7 +126,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
       return oldFloatList;
     } else {
       // Just a place holder, will set up the elements later.
-      return new PrimitiveFloatList();
+      return new PrimitiveFloatList(0);
     }
   }
 

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
@@ -81,6 +81,26 @@ public class FastDeserializerDefaultsTest {
   }
 
   @Test
+  public void testPrimitiveFloatListAddPrimitive() {
+    int array_size = 2500, iteration = 1000;
+    float w = 0;
+    long startTime = System.currentTimeMillis();
+
+    for (int i = 0; i < iteration; i++) {
+      PrimitiveFloatList list = new PrimitiveFloatList(array_size);
+
+      for (int l = 0; l < array_size; l++) {
+        list.addPrimitive((float) l);
+      }
+      for (Float f : list) {
+        w += f;
+      }
+    }
+    long endTime = System.currentTimeMillis();
+    System.out.println(String.format("time taken to addPrimitive to float list: %d", endTime - startTime));
+  }
+
+  @Test
   public void testFastFloatArraySerDes()  {
     int array_size = 2500, iteration = 100_000;
     long total = 0, endTime, startTime, w = 0;


### PR DESCRIPTION
Setup composite byte buffer even for general non-avro List interface implementaion of PrimitiveFloatList usage.
eg
PrimitiveFloatList list = new PrimitiveFloatList(10);

It will not use the ByteBuffer code, but cacheFromByteBuffer tries to read from the ByteBuffer array, which would fail if it is not initialized.